### PR TITLE
SDHostNode: handle invalid bay_identifier attribute (fixes #7)

### DIFF
--- a/sasutils/cli/sas_counters.py
+++ b/sasutils/cli/sas_counters.py
@@ -100,7 +100,7 @@ class SDHostNode(SDNode):
                     sortv[1] = -int(port_n.end_devices[0].targets[0].attrs.type)
                     sortv[2] = int(port_n.end_devices[0].sas_device.attrs
                                    .bay_identifier)
-            except RuntimeError:
+            except (RuntimeError, ValueError):
                 pass
             return sortv
 


### PR DESCRIPTION
Any attempt to read the bay_identifier sysfs file returns EINVAL for some
sas_end_devices, it seems. Handle this case in sas_counters.py by catching the
corresponding exception.